### PR TITLE
bugfix: fix "attempt to shift left with overflow" exception

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -209,7 +209,11 @@ fn decode_truncated_block_i32(data: &[u8], bit_size: usize) -> Vec<i32> {
         for i in 0..((bit_size + 7) / 8) {
             temp |= (data[byte_offset + i] as i32) << (i * 8);
         }
-        let value = (temp >> bit_remainder) & ((1 << bit_size) - 1);
+        let mut bit_mask: i32 = 0;
+        for i in 0..bit_size {
+            bit_mask |= 1<<i;
+        }
+        let value = (temp >> bit_remainder) & bit_mask;
         samples.push(value);
 
         bit_offset += bit_size;


### PR DESCRIPTION
I spotted this because it causes a few tests to fail.

The expression inside `decode_truncated_block_i32` function that is used to get a bitmask for given bit_size will fail in case `bit_size == 32`. Expression `1<<32` will be evaluated first which will cause "attempt to shift left with overflow" exception since `1<<32` value does not fit in `i32` type. Let's compute the bitmask incrementally from zero instead of backward arithmetic to avoid the type overflow.